### PR TITLE
Restore attribution: This repository copies significant portions of https://github.com/mike42/escpos-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,6 @@ http://www.youtube.com/watch?v=k1KTLC01mtM
         $printer->cut();
         // If you are creating multiple pages, I would ensure you put
         // sleep(1); so that the print doesn't get congested and stop working
+
+# Attribution
+This library is a modified version of escpos-php, a Library to work with ESC/POS thermal printers, implemented by Michael Billington. Further documentation is available at [https://github.com/mike42/escpos-php](https://github.com/mike42/escpos-php).

--- a/php-print.php
+++ b/php-print.php
@@ -1,10 +1,28 @@
 <?php
 /**
- *
- *  AUTHOR: Warren Doyle (wdoyle)
- *
- *  If you wish to expand this library you can use the below link:
- *  http://content.epson.de/fileadmin/content/files/RSD/downloads/escpos.pdf
+ * Copyright (c) 2014 Michael Billington <michael.billington@gmail.com>,
+ *   with additions by Warren Doyle (wdoyle)
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * 
+ * If you wish to expand this library you can use the below link:
+ * http://content.epson.de/fileadmin/content/files/RSD/downloads/escpos.pdf
  */
 define("DEBUG_MODE", 0);
 


### PR DESCRIPTION
This repository, in its current form, infringes copyright.

The "First Release" contains code for generating print commands in php-print.php:

https://github.com/wdoyle/EpsonESCPOS-PHP/commit/13e732f040d96b15aa828597c23f522b58ce11fa

The commit includes a copy of a PHP receipt printer driver which I maintain, but with the copyright notice removed:

https://github.com/mike42/escpos-php/blob/bef750ed557da3290deb8815f06bbda35062c355/escpos.php

As this code is MIT-licensed, it would be fine for you to use and improve the driver, provided that you correctly attribute it. I've created a pull request which will acknowledge the source and copyright status of the code, in order to comply with the licensing terms.

To fix this issue, please accept this pull request.
